### PR TITLE
Add --raw plaintext output to xor-bruteforce

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ import sys
 pt=b'hello world'; key=0x42
 sys.stdout.buffer.write(bytes([b ^ key for b in pt]))
 PY
+# plaintext only (no key/score metadata)
+# ... | bake crypto xor-bruteforce --raw
 # limit output if needed
 # ... | bake crypto xor-bruteforce --top 20
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -800,6 +800,7 @@ Options:
       --prefix <PREFIX>        
       --suffix <SUFFIX>        
       --word <WORD>            
+  -r, --raw                    Print only plaintext, one line per candidate
   -h, --help                   Print help
   -V, --version                Print version
 ```

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -389,6 +389,12 @@ pub enum CryptoCommands {
         suffix: Option<String>,
         #[clap(long = "word")]
         word: Vec<String>,
+        #[clap(
+            long = "raw",
+            short = 'r',
+            help = "Print only plaintext, one line per candidate"
+        )]
+        raw: bool,
     },
     JwtDecode,
     JwtSignHs256 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -544,6 +544,7 @@ fn main() -> Result<()> {
                 prefix,
                 suffix,
                 word,
+                raw,
             } => {
                 let results = transform::xor::brute_force(
                     stdin.trimmed_bytes()?,
@@ -556,6 +557,11 @@ fn main() -> Result<()> {
                 )?;
 
                 for c in results {
+                    if *raw {
+                        println!("{}", c.plaintext);
+                        continue;
+                    }
+
                     let key_hex: String = c.key.iter().map(|b| format!("{b:02x}")).collect();
                     println!(
                         "key=0x{} key_bytes={} score={:.3} text={}",


### PR DESCRIPTION
## Summary
- add plaintext-only output mode to XOR bruteforce:
  - `--raw` / `-r`
- when enabled, prints only candidate plaintext (one line per candidate)
- keeps existing detailed output (`key=... score=... text=...`) as default
- update README examples and regenerate docs/USAGE

## Example
```bash
python3 - <<'PY' | bake crypto xor-bruteforce -r --word hello
import sys
pt=b'hello world'; key=0x42
sys.stdout.buffer.write(bytes([b ^ key for b in pt]))
PY
```

## Validation
- cargo fmt
- cargo test --all-targets
- cargo clippy --all-targets -- -D warnings
